### PR TITLE
Add directions to an itinerary

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -244,9 +244,10 @@ p {
 }
 .map {
   display: flex;
-  justify-content: center;
+  justify-content: space-evenly;
   height: 80%;
   margin-top: 20px;
+  flex-direction: row;
 }
 
 .button {
@@ -392,4 +393,25 @@ p {
 
 .link-itinerary {
   color: #c24646;
+}
+
+#instructions {
+  position: relative;
+  width: 25%;
+  top: 0;
+  bottom: 20%;
+  padding: 20px;
+  background-color: #ffffff;
+  overflow-y: scroll;
+  font-family: sans-serif;
+}
+
+.hidden {
+  display:none;
+}
+
+.dir-btn {
+  height: 40px;
+
+  width: auto;
 }

--- a/client/src/components/CreateItinerary.js
+++ b/client/src/components/CreateItinerary.js
@@ -198,7 +198,7 @@ function CreateItinerary() {
 
                     <br/>
                     <br/>
-                    {itinerary.length > 1
+                    {itinerary.length > 1 && itinerary.length < 13
                         ?<div>
                             {!loadingItinerary && <h2>Your Itinerary Stops</h2>}
                             <br/>
@@ -215,7 +215,7 @@ function CreateItinerary() {
                                 <CustomItineraryMap key="map" data={itinerary} />
                             }
                         </div>
-                        :<div>{!loadingItinerary && <p>Add at least two stops to your itinerary!</p>}</div>
+                        :<div>{!loadingItinerary  && <p>{itinerary.length<2?"Add at least two stops to your itinerary!":"Only up to 12 stops can be added to your itinerary"}</p>}</div>
                     }
                     <br/> 
                 </form>


### PR DESCRIPTION
After an itinerary is created or you go to the preset itineraries page, each map will have routes draw on top. Directions from one stop to the next can also be seen after clicking on the "Show Directions" button. The MapBox API can only do optimized routing for up to 12 stops, so I limited the number of stops a user can add to their itinerary. I plan on adding different transportation modes later as seen [here](https://docs.mapbox.com/api/navigation/optimization-v1/#retrieve-an-optimization).
Closes #40 