### PR TITLE
users can save itineraries

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -415,3 +415,11 @@ p {
 
   width: auto;
 }
+
+.saved-itinerary{
+  text-align: left;
+}
+
+.saved-itinerary-div{
+  width: 50%;
+}

--- a/client/src/components/Account.js
+++ b/client/src/components/Account.js
@@ -73,7 +73,7 @@ function Account() {
                 <h2>Itinerary</h2>
                 {itinerary.itinerary.map((site) => {
                     return (
-                        <div>
+                        <div key={site._id}>
                             {buildSiteCard(site)}
                         </div>
                     )

--- a/client/src/components/Account.js
+++ b/client/src/components/Account.js
@@ -1,14 +1,135 @@
-import React from "react";
+import React , {useState, useEffect} from 'react';
+import { getAuth, onAuthStateChanged } from "firebase/auth";
 import SignOutButton from "./SignOut";
-import ChangePassword from './ChangePassword';
+import axios from 'axios';
 
 function Account() {
-    return (
-        <div>
-            <h2>User Account</h2>
-            <SignOutButton />
-        </div>
-    )
+    //const [uid, setUid] = useState(null);
+    const [user, setUser] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [loadingUser, setLoadingUser] = useState(true);
+    const [mongoUser, setMongoUser] = useState(null);
+    const [name, setName] = useState("");
+    let card = null;
+    //const [file, setFile] = useState(null);
+    //const [upload, setUpload] = useState("https://img.freepik.com/free-psd/3d-illustration-person-with-glasses_23-2149436191.jpg?size=626&ext=jpg&ga=GA1.1.55329923.1683053289&semt=robertav1_2_sidr");
+    let auth = getAuth();
+
+    useEffect(()=>{
+        onAuthStateChanged(auth, (user) => {
+            if(user){  
+                setUser(user);
+                //le.log(user);
+                setName(user.displayName);
+                setLoading(false);
+            } else {
+                setLoading(false);
+            }
+        });
+    }, [auth, name])
+
+    useEffect(() => {
+        const getUser = async (uid) => {
+            const { data } = await axios.get("http://localhost:3001/user/"+uid);
+            setMongoUser(data);
+            setLoadingUser(false);
+        };
+        if(!loading){
+            getUser(user.uid);
+        }
+    }, [loading, user]);
+
+    const buildSiteCard = (site) => {
+        return (
+            <div key={'div'+site._id} className='revolution'>
+                <hr/>
+                <h1 className='itinerary-stop-title'>{site.name}</h1>
+                <div className='itinerary-container'>
+                    <div className='customImageItinerary'>
+                        <img className='resize-image' src={site.image} alt='federal hall'/>
+                    </div>
+                    <div className='grid-item step-description'>
+                        <ul id='description-list'>
+                            {site.description.map((line) => (
+                            <li key={line}>{line}</li>
+                            ))}
+                        </ul> 
+                    </div>
+                </div>
+            </div>
+            
+        )
+    }
+
+    mongoUser && mongoUser.itineraries && mongoUser.itineraries.length !== 0 && mongoUser.itineraries.forEach(itinerary => {
+        card = itinerary.itinerary.map((site) => {
+            return buildSiteCard(site);
+        })
+    });
+
+    card = mongoUser && mongoUser.itineraries && mongoUser.itineraries.map((itinerary) => {
+        return (
+            <div key={itinerary.id}>
+                <h2>Itinerary</h2>
+                {itinerary.itinerary.map((site) => {
+                    return (
+                        <div>
+                            {buildSiteCard(site)}
+                        </div>
+                    )
+                })}
+                {!loading && !loadingUser && 
+                    <button onClick={(async (e) => {
+                        //console.log(sites)
+                        try{
+                            const { data } = await axios.get("http://localhost:3001/deleteItinerary/"+user.uid, {
+                                params: {
+                                    itinerary: JSON.stringify(itinerary)
+                                }
+                            })
+                            //console.log(data);
+                            setMongoUser(data);
+                            alert("Itinerary unsaved");
+                            window.location.reload();
+                        }catch(e) {
+                            alert("Error: You have not saved this itinerary");
+                        }
+                    })}>Unsave Itinerary</button>
+                }
+                <hr className="hr-custom"/>
+                <hr className="hr-custom"/>
+                <br/>
+            </div>
+        )
+    })
+
+
+    if (!loading && user.displayName && !loadingUser) {
+        return (
+            <div className='account-wrapper'>
+                <h1 className='grid-item account-title'>
+                    {user.displayName}'s Account
+                </h1>
+                <div className='account-signout'>
+                    <SignOutButton/>
+                </div> 
+                <br/>
+                <div>
+                    {mongoUser && mongoUser.itineraries && mongoUser.itineraries.length !== 0
+                        ?<div>
+                            <h2>Your saved itineraries:</h2>
+                            <hr className="hr-custom"/>
+                            <hr className="hr-custom"/>
+                            <div>{card}</div>
+                        </div>
+                        :<h2>You don't have any itineraries saved</h2>
+                    }
+                </div> 
+            </div>
+        );
+    } else if (loading) {
+        return <div>Loading...</div>;
+    }
 }
 
 export default Account;

--- a/client/src/components/Account.js
+++ b/client/src/components/Account.js
@@ -60,16 +60,10 @@ function Account() {
             
         )
     }
-
-    mongoUser && mongoUser.itineraries && mongoUser.itineraries.length !== 0 && mongoUser.itineraries.forEach(itinerary => {
-        card = itinerary.itinerary.map((site) => {
-            return buildSiteCard(site);
-        })
-    });
-
+    
     card = mongoUser && mongoUser.itineraries && mongoUser.itineraries.map((itinerary) => {
         return (
-            <div key={itinerary.id}>
+            <div key={itinerary.ids}>
                 <h2>Itinerary</h2>
                 {itinerary.itinerary.map((site) => {
                     return (
@@ -114,12 +108,11 @@ function Account() {
                     <SignOutButton/>
                 </div> 
                 <br/>
+                <hr className='hr-custom'/>
                 <div>
                     {mongoUser && mongoUser.itineraries && mongoUser.itineraries.length !== 0
                         ?<div>
                             <h2>Your saved itineraries:</h2>
-                            <hr className="hr-custom"/>
-                            <hr className="hr-custom"/>
                             <div>{card}</div>
                         </div>
                         :<h2>You don't have any itineraries saved</h2>

--- a/client/src/components/BrooklynBattles.js
+++ b/client/src/components/BrooklynBattles.js
@@ -110,7 +110,7 @@ function BrooklynBattles() {
             </div>
             <hr/>
             {!loading &&
-                <CustomItineraryMap key="map" data={sites} />
+                <CustomItineraryMap key="map" data={sites} id="Brooklyn"/>
             }
         </div>
     )

--- a/client/src/components/BrooklynBattles.js
+++ b/client/src/components/BrooklynBattles.js
@@ -1,10 +1,32 @@
 import axios from "axios";
 import { useState, useEffect } from "react";
 import CustomItineraryMap from './CustomItineraryMap';
+import { getAuth, onAuthStateChanged } from "firebase/auth";
 
 function BrooklynBattles() {
     const [sites, setSites] = useState([]);
     const [loading, setLoading] = useState(true);
+    const [user, setUser] = useState(null);
+    const [loadingUser, setLoadingUser] = useState(true);
+    const [mongoUser, setMongoUser] = useState(null);
+    const [name, setName] = useState("");
+    let auth = getAuth();
+
+    useEffect(()=>{
+        onAuthStateChanged(auth, (user) => {
+            if(user){  
+                setUser(user);
+                //le.log(user);
+                setName(user.displayName)
+                if(name !== ""){
+                    console.log(name); 
+                    setLoadingUser(false);
+                }
+            } else {
+                setLoadingUser(false);
+            }
+        });
+    }, [auth, name])
 
     useEffect(() => {
         const getSite = async (name) => {
@@ -111,6 +133,51 @@ function BrooklynBattles() {
             <hr/>
             {!loading &&
                 <CustomItineraryMap key="map" data={sites} />
+            }
+            <br/>
+            {!loading && !loadingUser &&
+                <button onClick={(async (e) => {
+                    //console.log(sites)
+                try{
+                    const { data } = await axios.get("http://localhost:3001/addItinerary/"+user.uid, {
+                        params: {
+                            itinerary: JSON.stringify(sites)
+                        }
+                    })
+                    console.log(data)
+                    setMongoUser(data);
+                    alert("Itinerary saved");
+                }catch(e){
+                    alert("Error: You already saved this itinerary");
+                }
+                })}>Save Itinerary</button>
+            }
+            <br/>
+            <br/>
+            {!loading && !loadingUser &&
+                <button onClick={(async (e) => {
+                    //console.log(sites)
+                    let itineraryId = "";
+                    sites.forEach(site => {
+                        itineraryId = itineraryId + site._id;
+                    })
+                    let temp = {
+                        id: itineraryId,
+                        itinerary: sites
+                    }
+                    try{
+                        const { data } = await axios.get("http://localhost:3001/deleteItinerary/"+user.uid, {
+                            params: {
+                                itinerary: JSON.stringify(temp)
+                            }
+                        })
+                        console.log(data);
+                        setMongoUser(data);
+                        alert("Itinerary unsaved");
+                    }catch(e){
+                        alert("Error: you have not saved this itinerary");
+                    }
+                })}>Unsave Itinerary</button>
             }
         </div>
     )

--- a/client/src/components/BrooklynBattles.js
+++ b/client/src/components/BrooklynBattles.js
@@ -8,7 +8,6 @@ function BrooklynBattles() {
     const [loading, setLoading] = useState(true);
     const [user, setUser] = useState(null);
     const [loadingUser, setLoadingUser] = useState(true);
-    const [mongoUser, setMongoUser] = useState(null);
     const [name, setName] = useState("");
     let auth = getAuth();
 
@@ -47,6 +46,49 @@ function BrooklynBattles() {
         getSite("Green-Wood Cemetery");
         getSite("John Paul Jones Park");
     }, [sites]);
+    
+    const [saved, setSaved] = useState(false);
+    const [itineraries, setItineraries] = useState([]);
+    const [mongoUser, setMongoUser] = useState(null);
+    const [loadingMongo, setLoadingMongo] = useState(true);
+    useEffect(() => {
+        const getUser = async (uid) => {
+            const { data } = await axios.get("http://localhost:3001/user/"+uid);
+            setMongoUser(data);
+            setLoadingMongo(false);
+            mongoUser && setItineraries(user.itineraries);
+        };
+        if(!loading){
+            getUser(user.uid);
+        }
+    }, [loading, user, mongoUser]);
+
+    useEffect(() => {
+        const checkAdded = async(uid, itinerary) => {
+            try{
+                const { data } = await axios.get("http://localhost:3001/has/"+uid, {
+                    params: {
+                        itinerary: JSON.stringify(itinerary)
+                    }
+                })
+                setSaved(data);
+            }catch(e){
+                console.log(e);
+            }
+        }
+        let id_array = [];
+        sites.forEach(site => {
+            id_array.push(site._id);
+        })
+        let temp = {
+            ids: id_array,
+            itinerary: sites
+        }
+        if(!loadingMongo){
+            checkAdded(user.uid, temp)
+        }
+
+    }, [itineraries, sites, loading, loadingMongo, user]);
 
     return (
         <div className='revolution'>
@@ -135,49 +177,51 @@ function BrooklynBattles() {
                 <CustomItineraryMap key="map" data={sites} />
             }
             <br/>
-            {!loading && !loadingUser &&
-                <button onClick={(async (e) => {
-                    //console.log(sites)
-                try{
-                    const { data } = await axios.get("http://localhost:3001/addItinerary/"+user.uid, {
-                        params: {
-                            itinerary: JSON.stringify(sites)
+            {!saved
+            ?<div>
+                {!loading && !loadingUser && 
+                    <button onClick={(async (e) => {
+                        //console.log(sites)
+                        try{
+                            await axios.get("http://localhost:3001/addItinerary/"+user.uid, {
+                                params: {
+                                    itinerary: JSON.stringify(sites)
+                                }
+                            })
+                            alert("Itinerary saved");
+                            setSaved(true);
+                        }catch(e){
+                            alert("Error: You already saved this itinerary");
                         }
-                    })
-                    console.log(data)
-                    setMongoUser(data);
-                    alert("Itinerary saved");
-                }catch(e){
-                    alert("Error: You already saved this itinerary");
+                    })}>Save Itinerary</button>
                 }
-                })}>Save Itinerary</button>
-            }
-            <br/>
-            <br/>
-            {!loading && !loadingUser &&
-                <button onClick={(async (e) => {
-                    //console.log(sites)
-                    let itineraryId = "";
-                    sites.forEach(site => {
-                        itineraryId = itineraryId + site._id;
-                    })
-                    let temp = {
-                        id: itineraryId,
-                        itinerary: sites
-                    }
-                    try{
-                        const { data } = await axios.get("http://localhost:3001/deleteItinerary/"+user.uid, {
-                            params: {
-                                itinerary: JSON.stringify(temp)
-                            }
+            </div>
+            :<div>
+                {!loading && !loadingUser && 
+                    <button onClick={(async (e) => {
+                        //console.log(sites)
+                        let id_array = [];
+                        sites.forEach(site => {
+                            id_array.push(site._id)
                         })
-                        console.log(data);
-                        setMongoUser(data);
-                        alert("Itinerary unsaved");
-                    }catch(e){
-                        alert("Error: you have not saved this itinerary");
-                    }
-                })}>Unsave Itinerary</button>
+                        let temp = {
+                            ids: id_array,
+                            itinerary: sites
+                        }
+                        try{
+                            await axios.get("http://localhost:3001/deleteItinerary/"+user.uid, {
+                                params: {
+                                    itinerary: JSON.stringify(temp)
+                                }
+                            })
+                            alert("Itinerary unsaved");
+                            setSaved(false);
+                        }catch(e) {
+                            alert("Error: You have not saved this itinerary");
+                        }
+                    })}>Unsave Itinerary</button>
+                }
+            </div>
             }
         </div>
     )

--- a/client/src/components/CreateItinerary.js
+++ b/client/src/components/CreateItinerary.js
@@ -212,7 +212,7 @@ function CreateItinerary() {
                             {!loadingItinerary && <div>{card}</div>}
                             {!loadingItinerary && <div className='revolution'><hr/></div>} 
                             {!loadingItinerary &&
-                                <CustomItineraryMap key="map" data={itinerary} />
+                                <CustomItineraryMap key="map" data={itinerary} id="Custom"/>
                             }
                         </div>
                         :<div>{!loadingItinerary  && <p>{itinerary.length<2?"Add at least two stops to your itinerary!":"Only up to 12 stops can be added to your itinerary"}</p>}</div>

--- a/client/src/components/CreateItinerary.js
+++ b/client/src/components/CreateItinerary.js
@@ -6,6 +6,7 @@ import CustomItineraryMap from './CustomItineraryMap';
 import ItineraryList from './ItineraryList';
 import ReactDOMServer from 'react-dom/server';
 import { getAuth, onAuthStateChanged } from "firebase/auth";
+import { Link } from 'react-router-dom';
 mapboxgl.accessToken = process.env.REACT_APP_MAPBOX_API_KEY;
 
 function CreateItinerary() {
@@ -109,7 +110,7 @@ function CreateItinerary() {
             mongoUser && setItineraries(user.itineraries);
         };
         if(!loadingUser){
-            getUser(user.uid);
+            user && getUser(user.uid);
         }
     }, [loadingUser, user, mongoUser]);
 
@@ -239,7 +240,8 @@ function CreateItinerary() {
                 <div className='create-itinerary-paragraph'>
                     <p>Select the sites which you would like to visit on your trip to NYC! Then click the Load Itinerary button to see your itinerary generated in the ordeer in which you selected your sites.</p>
                 </div>
-                <form>
+                {user
+                ?<div><form>
                     {manhattan.length !== 0 && <h3>Manhattan:</h3>}
                     {checkManhattan}
                     <br/>
@@ -283,7 +285,7 @@ function CreateItinerary() {
                             <br/>
                             {!saved
                             ?<div>
-                                {!loading && !loadingUser && !loadingMongo && !loadingItinerary &&
+                                {!loading && user && !loadingUser && !loadingMongo && !loadingItinerary &&
                                     <button onClick={(async (e) => {
                                         e.preventDefault();
                                         //console.log(sites)
@@ -334,6 +336,9 @@ function CreateItinerary() {
                     }
                     <br/> 
                 </form>
+                </div>
+                :<p><Link to="/signin">Login</Link> to create your own itinerary</p>
+                }
             </div>
         )
     }     

--- a/client/src/components/CustomItineraryMap.js
+++ b/client/src/components/CustomItineraryMap.js
@@ -73,7 +73,7 @@ function CustomItineraryMap(props) {
         `https://api.mapbox.com/optimized-trips/v1/mapbox/walking/${coordinates}?steps=true&geometries=geojson&access_token=${mapboxgl.accessToken}`
       );
       if (data.trips) {
-        const instructions = document.getElementById("instructions");
+        const instructions = document.getElementById(`instructions${props.id}`);
         let steps = [];
         data.trips[0].legs.map((leg) => {
           steps = [...steps, ...leg.steps];
@@ -137,7 +137,7 @@ function CustomItineraryMap(props) {
   }, [markerData]);
 
   useEffect(() => {
-    const instructionsDivv = document.getElementById("instructions");
+    const instructionsDivv = document.getElementById(`instructions${props.id}`);
     if (showDirections) {
       instructionsDivv.classList.remove("hidden");
     } else {
@@ -159,7 +159,7 @@ function CustomItineraryMap(props) {
         >
           {!showDirections ? "Show directions" : "Hide directions"}
         </button>
-        <div id="instructions" className="hidden">
+        <div id={`instructions${props.id}`} className="hidden">
           {!routeAvailable && <p>No route available</p>}
         </div>
       </div>

--- a/client/src/components/CustomItineraryMap.js
+++ b/client/src/components/CustomItineraryMap.js
@@ -171,14 +171,12 @@ function CustomItineraryMap(props) {
           {!showDirections ? "Show directions" : "Hide directions"}
         </button>
        <div>
-       <form>
           <label htmlFor="transportMode">Transportation Mode:</label>
           <select name="transportMode" onChange={(e)=>changeHandler(e.target.value)}>
             <option value="walking">Walking</option>
             <option value="cycling">Cycling</option>
             <option value="driving">Driving</option>
           </select>
-        </form>
        </div>
         <div id={`instructions${props.id}`} className="hidden">
         

--- a/client/src/components/PopularItineraries.js
+++ b/client/src/components/PopularItineraries.js
@@ -1,16 +1,35 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Revolution from "./Revolution";
 import Staten from "./Staten";
 import BrooklynBattles from "./BrooklynBattles";
 import { Link } from "react-router-dom";
 import ReactDOMServer from 'react-dom/server'
 import axios from "axios";
+import { getAuth, onAuthStateChanged } from "firebase/auth";
 
 function PopularItineraries() {
     const [revolution, setRevolution] = useState(false);
     const [staten, setStaten] = useState(false);
     const [battle, setBattle] = useState(false);
     const [pdfReady, setPdfReady] = useState({revolution: false, staten: false})
+    const [user, setUser] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [name, setName] = useState("");
+    let auth = getAuth();
+
+    useEffect(()=>{
+        onAuthStateChanged(auth, (user) => {
+            if(user){  
+                setUser(user);
+                //le.log(user);
+                setName(user.displayName);
+                setLoading(false);
+            } else {
+                setLoading(false);
+            }
+        });
+    }, [auth, name])
+
     const generatePdf = async (component, name) => {
         try{
             let {data} = await axios.post('http://localhost:3001/generatepdf',{input: component, name:name});
@@ -59,14 +78,19 @@ function PopularItineraries() {
                     on the Manhattan Revolutionary Tour. 
                 </div>
             </div>
-            {!revolution
-                ? <button onClick={()=>{setRevolution(true)}}>More Information</button>
-                : <button onClick={()=>{
-                    setRevolution(false);
-                    setPdfReady(prev => ({
-                    ...prev,
-                    ...{revolution: false}
-                  }))}}>Less Information</button>
+            {!loading && user
+            ? <div>
+                {!revolution
+                    ? <button onClick={()=>{setRevolution(true)}}>More Information</button>
+                    : <button onClick={()=>{
+                        setRevolution(false);
+                        setPdfReady(prev => ({
+                        ...prev,
+                        ...{revolution: false}
+                    }))}}>Less Information</button>
+                }
+            </div>
+            :<p><Link to="/signin" >Login</Link> to see more information</p>
             }
             {revolution && <button onClick={()=>generatePdf(ReactDOMServer.renderToString(<Revolution />), "revolution")}>Generate PDF</button>}
             {pdfReady.revolution === "Pdf is ready to print/download" ? <div><br/><a href='http://localhost:3001/generatepdf/revolution' target="_blank" rel="noreferrer">{pdfReady.revolution}</a></div> : <p>{pdfReady.revolution}</p>}
@@ -93,14 +117,19 @@ function PopularItineraries() {
                     fees. 
                 </div>
             </div>
-            {!staten
-                ? <button onClick={()=>{setStaten(true)}}>More Information</button>
-                : <button onClick={()=>{
-                    setStaten(false);
-                    setPdfReady(prev => ({
-                    ...prev,
-                    ...{staten: false}
-                  }))}}>Less Information</button>
+            {!loading && user
+            ? <div>
+                {!staten
+                    ? <button onClick={()=>{setStaten(true)}}>More Information</button>
+                    : <button onClick={()=>{
+                        setStaten(false);
+                        setPdfReady(prev => ({
+                        ...prev,
+                        ...{staten: false}
+                    }))}}>Less Information</button>
+                }
+            </div>
+            :<p><Link to="/signin" >Login</Link> to see more information</p>
             }
             {staten && <button onClick={()=>generatePdf(ReactDOMServer.renderToString(<Staten />), "staten")}>Generate PDF</button>}
             {pdfReady.staten === "Pdf is ready to print/download"? <div><br/><a href='http://localhost:3001/generatepdf/staten' target="_blank" rel="noreferrer">Pdf ready to print/download</a></div>:<p>{pdfReady.staten}</p>}
@@ -127,14 +156,19 @@ function PopularItineraries() {
                     of the battle fields in Brooklyn. 
                 </div>
             </div>
-            {!battle
-                ? <button onClick={()=>{setBattle(true)}}>More Information</button>
-                : <button onClick={()=>{
-                    setBattle(false);
-                    setPdfReady(prev => ({
-                    ...prev,
-                    ...{battle: false}
-                  }))}}>Less Information</button>
+            {!loading && user
+            ? <div>
+                {!battle
+                    ? <button onClick={()=>{setBattle(true)}}>More Information</button>
+                    : <button onClick={()=>{
+                        setBattle(false);
+                        setPdfReady(prev => ({
+                        ...prev,
+                        ...{battle: false}
+                    }))}}>Less Information</button>
+                }
+            </div>
+            :<p><Link to="/signin" >Login</Link> to see more information</p>
             }
             {battle && <button onClick={()=>generatePdf(ReactDOMServer.renderToString(<BrooklynBattles />), "battle")}>Generate PDF</button>}
             {pdfReady.battle && <div><br/><a href='http://localhost:3001/generatedpdf/battle' target="_blank" rel="noreferrer">Pdf ready to print/donwload</a></div>}

--- a/client/src/components/Revolution.js
+++ b/client/src/components/Revolution.js
@@ -150,7 +150,7 @@ function Revolution() {
             </div>
             <hr/>
             {!loading &&
-                <CustomItineraryMap key="map" data={sites} />
+                <CustomItineraryMap key="map" data={sites} id="Revolution"/>
             }
         </div>
     )

--- a/client/src/components/Revolution.js
+++ b/client/src/components/Revolution.js
@@ -1,10 +1,32 @@
 import axios from "axios";
 import { useState, useEffect } from "react";
 import CustomItineraryMap from './CustomItineraryMap';
+import { getAuth, onAuthStateChanged } from "firebase/auth";
 
 function Revolution() {
     const [sites, setSites] = useState([]);
     const [loading, setLoading] = useState(true);
+    const [user, setUser] = useState(null);
+    const [loadingUser, setLoadingUser] = useState(true);
+    const [mongoUser, setMongoUser] = useState(null);
+    const [name, setName] = useState("");
+    let auth = getAuth();
+
+    useEffect(()=>{
+        onAuthStateChanged(auth, (user) => {
+            if(user){  
+                setUser(user);
+                //le.log(user);
+                setName(user.displayName)
+                if(name !== ""){
+                    console.log(name); 
+                    setLoadingUser(false);
+                }
+            } else {
+                setLoadingUser(false);
+            }
+        });
+    }, [auth, name])
 
     useEffect(() => {
         const getSite = async (name) => {
@@ -151,6 +173,51 @@ function Revolution() {
             <hr/>
             {!loading &&
                 <CustomItineraryMap key="map" data={sites} />
+            }
+            <br/>
+            {!loading && !loadingUser &&
+                <button onClick={(async (e) => {
+                    //console.log(sites)
+                    try{
+                        const { data } = await axios.get("http://localhost:3001/addItinerary/"+user.uid, {
+                            params: {
+                                itinerary: JSON.stringify(sites)
+                            }
+                        })
+                        console.log(data)
+                        setMongoUser(data);
+                        alert("Itinerary saved");
+                    }catch(e){
+                        alert("Error: You already saved this itinerary");
+                    }
+                })}>Save Itinerary</button>
+            }
+            <br/>
+            <br/>
+            {!loading && !loadingUser &&
+                <button onClick={(async (e) => {
+                    //console.log(sites)
+                    let itineraryId = "";
+                    sites.forEach(site => {
+                        itineraryId = itineraryId + site._id;
+                    })
+                    let temp = {
+                        id: itineraryId,
+                        itinerary: sites
+                    }
+                    try{
+                        const { data } = await axios.get("http://localhost:3001/deleteItinerary/"+user.uid, {
+                            params: {
+                                itinerary: JSON.stringify(temp)
+                            }
+                        })
+                        //console.log(data)
+                        setMongoUser(data);
+                        alert("Itinerary unsaved");
+                    }catch(e){
+                        alert("Error: you have not saved this itinerary");
+                    }
+                })}>Unsave Itinerary</button>
             }
         </div>
     )

--- a/client/src/components/Revolution.js
+++ b/client/src/components/Revolution.js
@@ -8,7 +8,6 @@ function Revolution() {
     const [loading, setLoading] = useState(true);
     const [user, setUser] = useState(null);
     const [loadingUser, setLoadingUser] = useState(true);
-    const [mongoUser, setMongoUser] = useState(null);
     const [name, setName] = useState("");
     let auth = getAuth();
 
@@ -49,6 +48,49 @@ function Revolution() {
         getSite("St. Paul's Chapel");
         getSite("Federal Hall");
     }, [sites]);
+
+    const [saved, setSaved] = useState(false);
+    const [itineraries, setItineraries] = useState([]);
+    const [mongoUser, setMongoUser] = useState(null);
+    const [loadingMongo, setLoadingMongo] = useState(true);
+    useEffect(() => {
+        const getUser = async (uid) => {
+            const { data } = await axios.get("http://localhost:3001/user/"+uid);
+            setMongoUser(data);
+            setLoadingMongo(false);
+            mongoUser && setItineraries(user.itineraries);
+        };
+        if(!loading){
+            getUser(user.uid);
+        }
+    }, [loading, user, mongoUser]);
+
+    useEffect(() => {
+        const checkAdded = async(uid, itinerary) => {
+            try{
+                const { data } = await axios.get("http://localhost:3001/has/"+uid, {
+                    params: {
+                        itinerary: JSON.stringify(itinerary)
+                    }
+                })
+                setSaved(data);
+            }catch(e){
+                console.log(e);
+            }
+        }
+        let id_array = [];
+        sites.forEach(site => {
+            id_array.push(site._id);
+        })
+        let temp = {
+            ids: id_array,
+            itinerary: sites
+        }
+        if(!loadingMongo){
+            checkAdded(user.uid, temp)
+        }
+
+    }, [itineraries, sites, loading, loadingMongo, user]);
 
     return (
         <div className='revolution'>
@@ -175,49 +217,51 @@ function Revolution() {
                 <CustomItineraryMap key="map" data={sites} />
             }
             <br/>
-            {!loading && !loadingUser &&
-                <button onClick={(async (e) => {
-                    //console.log(sites)
-                    try{
-                        const { data } = await axios.get("http://localhost:3001/addItinerary/"+user.uid, {
-                            params: {
-                                itinerary: JSON.stringify(sites)
-                            }
+            {!saved
+            ?<div>
+                {!loading && !loadingUser && 
+                    <button onClick={(async (e) => {
+                        //console.log(sites)
+                        try{
+                            await axios.get("http://localhost:3001/addItinerary/"+user.uid, {
+                                params: {
+                                    itinerary: JSON.stringify(sites)
+                                }
+                            })
+                            alert("Itinerary saved");
+                            setSaved(true);
+                        }catch(e){
+                            alert("Error: You already saved this itinerary");
+                        }
+                    })}>Save Itinerary</button>
+                }
+            </div>
+            :<div>
+                {!loading && !loadingUser && 
+                    <button onClick={(async (e) => {
+                        //console.log(sites)
+                        let id_array = [];
+                        sites.forEach(site => {
+                            id_array.push(site._id)
                         })
-                        console.log(data)
-                        setMongoUser(data);
-                        alert("Itinerary saved");
-                    }catch(e){
-                        alert("Error: You already saved this itinerary");
-                    }
-                })}>Save Itinerary</button>
-            }
-            <br/>
-            <br/>
-            {!loading && !loadingUser &&
-                <button onClick={(async (e) => {
-                    //console.log(sites)
-                    let itineraryId = "";
-                    sites.forEach(site => {
-                        itineraryId = itineraryId + site._id;
-                    })
-                    let temp = {
-                        id: itineraryId,
-                        itinerary: sites
-                    }
-                    try{
-                        const { data } = await axios.get("http://localhost:3001/deleteItinerary/"+user.uid, {
-                            params: {
-                                itinerary: JSON.stringify(temp)
-                            }
-                        })
-                        //console.log(data)
-                        setMongoUser(data);
-                        alert("Itinerary unsaved");
-                    }catch(e){
-                        alert("Error: you have not saved this itinerary");
-                    }
-                })}>Unsave Itinerary</button>
+                        let temp = {
+                            ids: id_array,
+                            itinerary: sites
+                        }
+                        try{
+                            await axios.get("http://localhost:3001/deleteItinerary/"+user.uid, {
+                                params: {
+                                    itinerary: JSON.stringify(temp)
+                                }
+                            })
+                            alert("Itinerary unsaved");
+                            setSaved(false);
+                        }catch(e) {
+                            alert("Error: You have not saved this itinerary");
+                        }
+                    })}>Unsave Itinerary</button>
+                }
+            </div>
             }
         </div>
     )

--- a/client/src/components/SignIn.js
+++ b/client/src/components/SignIn.js
@@ -17,7 +17,7 @@ export default function Login () {
             .then((userCredential) => {
                 setEmail("");
                 setPassword("");
-                navigate("/account")
+                navigate("/")
             }).catch((error) => {
                 console.log(error);
             });

--- a/client/src/components/SignIn.js
+++ b/client/src/components/SignIn.js
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
 import {auth} from '../firebase';
 import {signInWithEmailAndPassword} from "firebase/auth";
+import { Link } from 'react-router-dom';
 import { useNavigate } from "react-router-dom";
 import '../App.css'
 import SocialSignIn from './SocialSignIn';
@@ -61,6 +62,7 @@ export default function Login () {
                 </div>
             </form>
             <br />
+            <Link to="/signup">Sign up</Link>
             <SocialSignIn />
         </div>
     );

--- a/client/src/components/SignUp.js
+++ b/client/src/components/SignUp.js
@@ -1,9 +1,10 @@
 import React, {useState} from "react";
 import { Link } from 'react-router-dom'
-import { createUserWithEmailAndPassword } from "firebase/auth";
-import {auth} from '../firebase.js'
+import { createUserWithEmailAndPassword, updateProfile } from "firebase/auth";
+import {auth} from '../firebase.js';
 import SocialSignIn from "./SocialSignIn.js";
 import { useNavigate } from "react-router-dom";
+import axios from "axios";
 
 function SignUp() {
     const [matchPassword, setMatchPassword] = useState('');
@@ -31,7 +32,13 @@ function SignUp() {
         try {
             await createUserWithEmailAndPassword(auth, email.value, passwordOne.value, displayName)
             .then((userCredential) => {
-                navigate("/account")
+                updateProfile(auth.currentUser, {
+                    displayName: displayName.value
+                }).then (async () => {
+                    const { data } = await axios.get("http://localhost:3001/adduser/" + userCredential.user.uid);
+                    console.log(data)
+                    navigate("/account")
+                })
             }).catch((error) => {
                 console.log(error);
             });
@@ -54,9 +61,9 @@ function SignUp() {
                         <input
                             className='form-control'
                             required
-                            name="full_name"
+                            name="displayName"
                             type="text"
-                            id="full_name"
+                            id="displayName"
                             onChange={event => setFullName(event.target.value)}
                             value={fullName}
                         />

--- a/client/src/components/Staten.js
+++ b/client/src/components/Staten.js
@@ -91,7 +91,7 @@ function Staten() {
             </div>
             <hr/>
             {!loading &&
-                <CustomItineraryMap key="map" data={sites} />
+                <CustomItineraryMap key="map" data={sites} id="Staten"/>
             }
         </div>
     )

--- a/client/src/components/Staten.js
+++ b/client/src/components/Staten.js
@@ -46,6 +46,49 @@ function Staten() {
         getSite("Historic Richmond Town");
     }, [sites]);
 
+    const [saved, setSaved] = useState(false);
+    const [itineraries, setItineraries] = useState([]);
+    const [mongoUser, setMongoUser] = useState(null);
+    const [loadingMongo, setLoadingMongo] = useState(true);
+    useEffect(() => {
+        const getUser = async (uid) => {
+            const { data } = await axios.get("http://localhost:3001/user/"+uid);
+            setMongoUser(data);
+            setLoadingMongo(false);
+            mongoUser && setItineraries(user.itineraries);
+        };
+        if(!loading){
+            getUser(user.uid);
+        }
+    }, [loading, user, mongoUser]);
+
+    useEffect(() => {
+        const checkAdded = async(uid, itinerary) => {
+            try{
+                const { data } = await axios.get("http://localhost:3001/has/"+uid, {
+                    params: {
+                        itinerary: JSON.stringify(itinerary)
+                    }
+                })
+                setSaved(data);
+            }catch(e){
+                console.log(e);
+            }
+        }
+        let id_array = [];
+        sites.forEach(site => {
+            id_array.push(site._id);
+        })
+        let temp = {
+            ids: id_array,
+            itinerary: sites
+        }
+        if(!loadingMongo){
+            checkAdded(user.uid, temp)
+        }
+
+    }, [itineraries, sites, loading, loadingMongo, user]);
+
     return (
         <div className='revolution'>
             <hr/>
@@ -115,45 +158,51 @@ function Staten() {
                 <CustomItineraryMap key="map" data={sites} />
             }
             <br/>
-            {!loading && !loadingUser && 
-                <button onClick={(async (e) => {
-                    //console.log(sites)
-                    try{
-                        const { data } = await axios.get("http://localhost:3001/addItinerary/"+user.uid, {
-                            params: {
-                                itinerary: JSON.stringify(sites)
-                            }
+            {!saved
+            ?<div>
+                {!loading && !loadingUser && 
+                    <button onClick={(async (e) => {
+                        //console.log(sites)
+                        try{
+                            await axios.get("http://localhost:3001/addItinerary/"+user.uid, {
+                                params: {
+                                    itinerary: JSON.stringify(sites)
+                                }
+                            })
+                            alert("Itinerary saved");
+                            setSaved(true);
+                        }catch(e){
+                            alert("Error: You already saved this itinerary");
+                        }
+                    })}>Save Itinerary</button>
+                }
+            </div>
+            :<div>
+                {!loading && !loadingUser && 
+                    <button onClick={(async (e) => {
+                        //console.log(sites)
+                        let id_array = [];
+                        sites.forEach(site => {
+                            id_array.push(site._id)
                         })
-                        alert("Itinerary saved");
-                    }catch(e){
-                        alert("Error: You already saved this itinerary");
-                    }
-                })}>Save Itinerary</button>
-            }
-            <br/>
-            <br/>
-            {!loading && !loadingUser && 
-                <button onClick={(async (e) => {
-                    //console.log(sites)
-                    let itineraryId = "";
-                    sites.forEach(site => {
-                        itineraryId = itineraryId + site._id;
-                    })
-                    let temp = {
-                        id: itineraryId,
-                        itinerary: sites
-                    }
-                    try{
-                        await axios.get("http://localhost:3001/deleteItinerary/"+user.uid, {
-                            params: {
-                                itinerary: JSON.stringify(temp)
-                            }
-                        })
-                        alert("Itinerary unsaved");
-                    }catch(e) {
-                        alert("Error: You have not saved this itinerary");
-                    }
-                })}>Unsave Itinerary</button>
+                        let temp = {
+                            ids: id_array,
+                            itinerary: sites
+                        }
+                        try{
+                            await axios.get("http://localhost:3001/deleteItinerary/"+user.uid, {
+                                params: {
+                                    itinerary: JSON.stringify(temp)
+                                }
+                            })
+                            alert("Itinerary unsaved");
+                            setSaved(false);
+                        }catch(e) {
+                            alert("Error: You have not saved this itinerary");
+                        }
+                    })}>Unsave Itinerary</button>
+                }
+            </div>
             }
         </div>
     )

--- a/server/config/mongoCollections.js
+++ b/server/config/mongoCollections.js
@@ -15,4 +15,5 @@ const getCollectionFn = (collection) => {
 
 module.exports = {
   sites: getCollectionFn("sites"),
+  users: getCollectionFn("users")
 };

--- a/server/data/index.js
+++ b/server/data/index.js
@@ -1,7 +1,9 @@
 const sites = require("./sites");
+const users = require("./users")
 
 module.exports = {
   sites: require("./sites"),
   reviews: require("./reviews"),
+  users: require("./users"),
   htmltopdf: require("./htmltopdf")
 };

--- a/server/data/users.js
+++ b/server/data/users.js
@@ -25,42 +25,43 @@ const addItinerary = async (
 ) => {
     uid = helpers.validString(uid);
 
-    /*if(!itinerary){
-        throw "ERROR: ITINERARY MUST BE PROVIDED";
-    }
-
-    if(typeof itinerary !== Object){
-        throw "ERROR: ITINERARY MUST BE OBJECT"
-    }*/
-
     const userCollection = await users();
 
     const user = await userCollection.findOne({ uid: uid });
     if (!user) throw "ERROR: USER NOT FOUND";
 
     let index = -1;
-    
-    //let itinerary_list = itineraries.splice(index, 1);
-
-    let itineraryid = "";
-    itinerary.forEach(stop => {
-        itineraryid = itineraryid + stop._id;
-    })
 
     let itineraries = user.itineraries;
+
+    let id_array = [];
+    itinerary.forEach(stop => {
+        id_array.push(stop._id);
+    })
+    
+    let equal = false;
+
     for(let i = 0; i < itineraries.length; i++){
-        if(itineraries[i].id === itineraryid){
+        id_array.forEach(id => {
+            if(itineraries[i].ids.length === id_array.length && itineraries[i].ids.includes(id)){
+                equal = true;
+            } else {
+                equal = false;
+            }
+        })
+        if(equal === true){
+            console.log(i);
             index = i;
         }
     }
 
     if(index !== -1){
-        throw "ERROR: USER HAS ALREADY SAVED ITINERARY";
+        throw "ERROR: USER HAS SAVED ITINERARY";
     }
 
     const updateInfo = await userCollection.updateOne(
         { uid: uid },
-        { $push: { itineraries: {id: itineraryid, itinerary: itinerary }} }
+        { $push: { itineraries: {ids: id_array, itinerary: itinerary }} }
     );
     if (updateInfo.modifiedCount === 0) {
         throw "ERROR: COULD NOT ADD ITINERARY";
@@ -76,27 +77,27 @@ const deleteItinerary = async (
     let index = -1;
     uid = helpers.validString(uid);
 
-    /*if(!itinerary){
-        throw "ERROR: ITINERARY MUST BE PROVIDED";
-    }
-
-    if(typeof itinerary !== Object){
-        throw "ERROR: ITINERARY MUST BE OBJECT"
-    }*/
-
     const userCollection = await users();
 
     const user = await userCollection.findOne({ uid: uid });
     if (!user) throw "ERROR: USER NOT FOUND";
-    
+
     let itineraries = user.itineraries;
+    
+    let equal = false;
+
     for(let i = 0; i < itineraries.length; i++){
-        if(itineraries[i].id === itinerary.id){
+        itinerary.ids.forEach(id => {
+            if(itineraries[i].ids.length === itinerary.ids.length && itineraries[i].ids.includes(id)){
+                equal = true;
+            } else {
+                equal = false;
+            }
+        })
+        if(equal === true){
             index = i;
         }
     }
-    
-    //let itinerary_list = itineraries.splice(index, 1);
     if(index === -1){
         throw "ERROR: USER HAS NOT SAVED ITINERARY";
     }
@@ -131,16 +132,8 @@ const userHasItinerary = async (
     uid,
     itinerary
 ) => {
+    let index = -1;
     uid = helpers.validString(uid);
-
-    /*if(!itinerary){
-        throw "ERROR: ITINERARY MUST BE PROVIDED";
-    }
-
-    if(typeof itinerary !== Object){
-        throw "ERROR: ITINERARY MUST BE OBJECT"
-    }*/
-    console.log(itinerary)
 
     const userCollection = await users();
 
@@ -148,12 +141,26 @@ const userHasItinerary = async (
     if (!user) throw "ERROR: USER NOT FOUND";
 
     let itineraries = user.itineraries;
+    
+    let equal = false;
+
     for(let i = 0; i < itineraries.length; i++){
-        if(itineraries[i].id === itinerary.id){
-            return true;
+        itinerary.ids.forEach(id => {
+            if(itineraries[i].ids.includes(id)){
+                equal = true;
+            } else {
+                equal = false;
+            }
+        })
+        if(equal === true){
+            index = i;
         }
     }
-    return false;
+    if(index === -1){
+        return false;
+    } else {
+        return true;
+    }
 }
 
 module.exports = {

--- a/server/data/users.js
+++ b/server/data/users.js
@@ -1,0 +1,165 @@
+const mongoCollections = require("../config/mongoCollections");
+const users = mongoCollections.users;
+const helpers = require("../validation");
+
+const createUser = async (
+  uid
+) => {
+    uid = helpers.validString(uid);
+
+    const userCollection = await users();
+
+    let newUser = {
+        uid: uid,
+        itineraries: []
+    };
+
+    const insertInfo = await userCollection.insertOne(newUser);
+    if (insertInfo.insertedCount === 0) throw "ERROR: COULD NOT ADD USER";
+    return newUser;
+};
+
+const addItinerary = async (
+    uid, 
+    itinerary
+) => {
+    uid = helpers.validString(uid);
+
+    /*if(!itinerary){
+        throw "ERROR: ITINERARY MUST BE PROVIDED";
+    }
+
+    if(typeof itinerary !== Object){
+        throw "ERROR: ITINERARY MUST BE OBJECT"
+    }*/
+
+    const userCollection = await users();
+
+    const user = await userCollection.findOne({ uid: uid });
+    if (!user) throw "ERROR: USER NOT FOUND";
+
+    let index = -1;
+    
+    //let itinerary_list = itineraries.splice(index, 1);
+
+    let itineraryid = "";
+    itinerary.forEach(stop => {
+        itineraryid = itineraryid + stop._id;
+    })
+
+    let itineraries = user.itineraries;
+    for(let i = 0; i < itineraries.length; i++){
+        if(itineraries[i].id === itineraryid){
+            index = i;
+        }
+    }
+
+    if(index !== -1){
+        throw "ERROR: USER HAS ALREADY SAVED ITINERARY";
+    }
+
+    const updateInfo = await userCollection.updateOne(
+        { uid: uid },
+        { $push: { itineraries: {id: itineraryid, itinerary: itinerary }} }
+    );
+    if (updateInfo.modifiedCount === 0) {
+        throw "ERROR: COULD NOT ADD ITINERARY";
+    };
+
+    return user;
+}
+
+const deleteItinerary = async (
+    uid, 
+    itinerary
+) => {
+    let index = -1;
+    uid = helpers.validString(uid);
+
+    /*if(!itinerary){
+        throw "ERROR: ITINERARY MUST BE PROVIDED";
+    }
+
+    if(typeof itinerary !== Object){
+        throw "ERROR: ITINERARY MUST BE OBJECT"
+    }*/
+
+    const userCollection = await users();
+
+    const user = await userCollection.findOne({ uid: uid });
+    if (!user) throw "ERROR: USER NOT FOUND";
+    
+    let itineraries = user.itineraries;
+    for(let i = 0; i < itineraries.length; i++){
+        if(itineraries[i].id === itinerary.id){
+            index = i;
+        }
+    }
+    
+    //let itinerary_list = itineraries.splice(index, 1);
+    if(index === -1){
+        throw "ERROR: USER HAS NOT SAVED ITINERARY";
+    }
+    let temp = itineraries.splice(index, 1);
+    console.log(itineraries);
+    console.log(temp);
+    const updateInfo = await userCollection.updateOne(
+        { uid: uid },
+        { $set: { itineraries: itineraries } }
+    );
+    if (updateInfo.modifiedCount === 0) {
+        throw "ERROR: COULD NOT DELETE ITINERARY";
+    };
+
+    return updateInfo;
+}
+
+const getUserById = async (
+    uid
+) => {
+    uid = helpers.validString(uid);
+
+    const userCollection = await users();
+
+    const user = await userCollection.findOne({ uid: uid });
+    if (!user) throw "ERROR: USER NOT FOUND";
+
+    return user;
+}
+
+const userHasItinerary = async (
+    uid,
+    itinerary
+) => {
+    uid = helpers.validString(uid);
+
+    /*if(!itinerary){
+        throw "ERROR: ITINERARY MUST BE PROVIDED";
+    }
+
+    if(typeof itinerary !== Object){
+        throw "ERROR: ITINERARY MUST BE OBJECT"
+    }*/
+    console.log(itinerary)
+
+    const userCollection = await users();
+
+    const user = await userCollection.findOne({ uid: uid });
+    if (!user) throw "ERROR: USER NOT FOUND";
+
+    let itineraries = user.itineraries;
+    for(let i = 0; i < itineraries.length; i++){
+        if(itineraries[i].id === itinerary.id){
+            return true;
+        }
+    }
+    return false;
+}
+
+module.exports = {
+    createUser,
+    addItinerary,
+    getUserById,
+    deleteItinerary,
+    userHasItinerary
+};

--- a/server/routes/routesAPI.js
+++ b/server/routes/routesAPI.js
@@ -2,6 +2,7 @@ const express = require("express");
 const router = express.Router();
 const data = require("../data");
 const sitesData = data.sites;
+const usersData = data.users;
 
  router
   .route('/siteBorough/:borough')
@@ -105,4 +106,58 @@ router.route("/sites/name/:name").get(async (req, res) => {
     return res.status(404).json({ error: e });
   }
 });
+
+router.route("/user/:uid").get(async (req, res) => {
+  let uid = req.params.uid;
+  try {
+    const user = await usersData.getUserById(uid);
+    return res.json(user);
+  } catch (e) {
+    return res.status(404).json({ error: e });
+  }
+});
+
+router.route("/adduser/:uid").get(async (req, res) => {
+  let uid = req.params.uid;
+  try {
+    const user = await usersData.createUser(uid);
+    return res.json(user);
+  } catch (e) {
+    return res.status(404).json({ error: e });
+  }
+});
+
+router.route("/addItinerary/:uid").get(async (req, res) => {
+  let uid = req.params.uid;
+  let itinerary = JSON.parse(req.query.itinerary);
+  try {
+    const user = await usersData.addItinerary(uid, itinerary);
+    return res.json(user);
+  } catch (e) {
+    return res.status(404).json({ error: e });
+  }
+});
+
+router.route("/deleteItinerary/:uid").get(async (req, res) => {
+  let uid = req.params.uid;
+  let itinerary = JSON.parse(req.query.itinerary);
+  try {
+    const user = await usersData.deleteItinerary(uid, itinerary);
+    return res.json(user);
+  } catch (e) {
+    return res.status(404).json({ error: e });
+  }
+});
+
+router.route("/has/:uid").get(async (req, res) => {
+  let uid = req.params.uid;
+  let itinerary = JSON.parse(req.query.itinerary);
+  try {
+    const user = await usersData.userHasItinerary(uid, itinerary);
+    return res.json(user);
+  } catch (e) {
+    return res.status(404).json({ error: e });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
I made it so that users can now save itineraries and view their saved itineraries on their account page. To do this, I made it so that a user is created in the mongo database when you register as a new user (meaning you will have to delete your account and reregister so that your user is created in the mongo database). 

On each of the preset itineraries, there should now be a Save Itinerary and Unsave Itinerary button. When the user clicks one, there should be an alert saying the itinerary has been saved or unsaved. If the user clicks the save button and they already have the itinerary saved, there should be an alert telling them that. If they click the unsave button and they don't currently have that itinerary saved, there should also be an alert telling them this. 

For the create your own itinerary, it works exactly the same. However, an itinerary is only considered to have already be saved if it is in the exact same order the user had saved the itinerary as before. for example if the user saves an itinerary as Federal Hall, Fraunces Tavern, then they would not be able to save another itinerary that is Federal Hall, Fraunces Tavern, but they would be able to save an itinerary that is Fraunces Tavern, Federal Hall. This is because of the way I set up the comparison in the data functions but I couldn't get another way to work. I do think this could be ok though since different orders could change the directions and/or timing of the itinerary. 

On the account page, if the user does not have any itineraries, it should say that. Otherwise, it should display the itineraries the user saved and there should be an unsave button at the bottom of each itinerary. 