### PR TITLE
Add Transportation Modes to Itinerary Map

### DIFF
--- a/client/src/components/BrooklynBattles.js
+++ b/client/src/components/BrooklynBattles.js
@@ -110,7 +110,7 @@ function BrooklynBattles() {
             </div>
             <hr/>
             {!loading &&
-                <CustomItineraryMap key="map" data={sites} />
+                <CustomItineraryMap key="map" data={sites} id="Brooklyn"/>
             }
         </div>
     )

--- a/client/src/components/CreateItinerary.js
+++ b/client/src/components/CreateItinerary.js
@@ -212,7 +212,7 @@ function CreateItinerary() {
                             {!loadingItinerary && <div>{card}</div>}
                             {!loadingItinerary && <div className='revolution'><hr/></div>} 
                             {!loadingItinerary &&
-                                <CustomItineraryMap key="map" data={itinerary} />
+                                <CustomItineraryMap key="map" data={itinerary} id="Custom"/>
                             }
                         </div>
                         :<div>{!loadingItinerary  && <p>{itinerary.length<2?"Add at least two stops to your itinerary!":"Only up to 12 stops can be added to your itinerary"}</p>}</div>

--- a/client/src/components/CustomItineraryMap.js
+++ b/client/src/components/CustomItineraryMap.js
@@ -73,7 +73,7 @@ function CustomItineraryMap(props) {
         `https://api.mapbox.com/optimized-trips/v1/mapbox/walking/${coordinates}?steps=true&geometries=geojson&access_token=${mapboxgl.accessToken}`
       );
       if (data.trips) {
-        const instructions = document.getElementById("instructions");
+        const instructions = document.getElementById(`instructions${props.id}`);
         let steps = [];
         data.trips[0].legs.map((leg) => {
           steps = [...steps, ...leg.steps];
@@ -137,7 +137,7 @@ function CustomItineraryMap(props) {
   }, [markerData]);
 
   useEffect(() => {
-    const instructionsDivv = document.getElementById("instructions");
+    const instructionsDivv = document.getElementById(`instructions${props.id}`);
     if (showDirections) {
       instructionsDivv.classList.remove("hidden");
     } else {
@@ -159,7 +159,7 @@ function CustomItineraryMap(props) {
         >
           {!showDirections ? "Show directions" : "Hide directions"}
         </button>
-        <div id="instructions" className="hidden">
+        <div id={`instructions${props.id}`} className="hidden">
           {!routeAvailable && <p>No route available</p>}
         </div>
       </div>

--- a/client/src/components/CustomItineraryMap.js
+++ b/client/src/components/CustomItineraryMap.js
@@ -171,14 +171,12 @@ function CustomItineraryMap(props) {
           {!showDirections ? "Show directions" : "Hide directions"}
         </button>
        <div>
-       <form>
           <label htmlFor="transportMode">Transportation Mode:</label>
           <select name="transportMode" onChange={(e)=>changeHandler(e.target.value)}>
             <option value="walking">Walking</option>
             <option value="cycling">Cycling</option>
             <option value="driving">Driving</option>
           </select>
-        </form>
        </div>
         <div id={`instructions${props.id}`} className="hidden">
         

--- a/client/src/components/Revolution.js
+++ b/client/src/components/Revolution.js
@@ -150,7 +150,7 @@ function Revolution() {
             </div>
             <hr/>
             {!loading &&
-                <CustomItineraryMap key="map" data={sites} />
+                <CustomItineraryMap key="map" data={sites} id="Revolution"/>
             }
         </div>
     )

--- a/client/src/components/Staten.js
+++ b/client/src/components/Staten.js
@@ -91,7 +91,7 @@ function Staten() {
             </div>
             <hr/>
             {!loading &&
-                <CustomItineraryMap key="map" data={sites} />
+                <CustomItineraryMap key="map" data={sites} id="Staten"/>
             }
         </div>
     )


### PR DESCRIPTION
Routes: /itineraries and /createItinerary

The user should be able to select either walking, cycling, or driving and on change the map should have new routes drawn on top. 